### PR TITLE
Add duration support

### DIFF
--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,0,0)
+__version_info__ = (1,1,0)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,3)
+__version_info__ = (1,1,4)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,1)
+__version_info__ = (1,1,2)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,2)
+__version_info__ = (1,1,3)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,0)
+__version_info__ = (1,1,1)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -46,7 +46,7 @@ AssertionExpires = 0
 @arg('--region',       help='AWS region to use', default=os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
 @arg('--batch',        help='Disable all interactive prompts')
 @arg('--all-accounts', help='Retrieve tokens for all accounts and roles')
-@arg('--profile',      help='Naming pattern for profile names; %a=account alias, %r=role name (default %a:%r)')
+@arg('--profile',      help='Naming pattern for profile names; %%a=account alias, %%r=role name (default %%a:%%r)')
 @arg('--account',      help='Name or ID of AWS account for which to generate token')
 @arg('--role',         help='Name or ARN of role for which to generate token (default: all for account)')
 @arg('--filename',     help='Name of AWS credentials file', default=CREDS_FILE)
@@ -220,6 +220,7 @@ def update_creds_file(filename, profile, token):
     credentials.set(profile, 'aws_session_token', token['Credentials']['SessionToken'])
     credentials.set(profile, 'aws_security_token', token['Credentials']['SessionToken'])
     credentials.set(profile, 'last_updated', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+    credentials.set(profile, 'expiration', token['Credentials']['Expiration'])
 
     with open(filename, 'w+') as credsfile:
         credentials.write(credsfile)

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -13,6 +13,7 @@ else:
 from argh import arg
 from collections import namedtuple
 from datetime import datetime
+import dateutil
 from fasteners.process_lock import interprocess_locked
 from multiprocessing import Process
 from os import path
@@ -158,7 +159,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
 
         if auto_update:
             trace('Token retrieval took {} seconds'.format(time.time() - started))
-            next_update = time.time() + 59 * 60
+            next_update = time.time() + validity - 60
             while time.time() < next_update:
                 counter = int((next_update - time.time()) // 60)
                 print('{} minutes till credential refresh\r'.format(counter), end='')
@@ -220,7 +221,7 @@ def update_creds_file(filename, profile, token):
     credentials.set(profile, 'aws_session_token', token['Credentials']['SessionToken'])
     credentials.set(profile, 'aws_security_token', token['Credentials']['SessionToken'])
     credentials.set(profile, 'last_updated', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
-    credentials.set(profile, 'expiration', token['Credentials']['Expiration'])
+    credentials.set(profile, 'expiration', datetime.strftime(token['Credentials']['Expiration'], '%FT%TZ'))
 
     with open(filename, 'w+') as credsfile:
         credentials.write(credsfile)

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -7,8 +7,11 @@ import sys
 if sys.version_info < (3, 0):
   import ConfigParser as configparser
   input = raw_input
+  from urlparse import urlparse
 else:
   import configparser
+  from urllib import parse as urlparse
+
 
 from argh import arg
 from collections import namedtuple
@@ -17,7 +20,6 @@ import dateutil
 from fasteners.process_lock import interprocess_locked
 from multiprocessing import Process
 from os import path
-from urlparse import urlparse
 
 
 

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 0):
   from urlparse import urlparse
 else:
   import configparser
-  from urllib import parse as urlparse
+  from urllib.parse import urlparse
 
 
 from argh import arg

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -264,6 +264,7 @@ def get_profile(filename, pattern, multi=False):
         return profiles[0]
 
 
+@interprocess_locked(LOCK_FILE)
 def load_profiles(filename, pattern):
     config = load_credentials(filename)
     regex = re.compile(pattern)


### PR DESCRIPTION
Allow user to request tokens of a specific duration when executing `authenticate` action; store expiration date of tokens in credentials file.