### PR TITLE
Fix account name retrieval for single-role users

### DIFF
--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,5)
+__version_info__ = (1,1,6)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Single-role users don't get a form listing their roles; they just get logged straight in. In that case we explicitly ask IAM for the account alias so we can give the credentials profile a proper name.
