### PR TITLE
Reduce docker image footprint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/.git
+/README.rst
+/__pycache__
+/dist
+/**/*.pyc
+/*.egg-info
+/.eggs
+/build
+/**/.*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM python:2.7.13
+FROM alpine:3.7
 
-RUN mkdir -p /usr/src/app
+RUN apk --update add --no-cache python=2.7.14-r2 bash libffi openssl
+
 COPY . /usr/src/app
 WORKDIR /usr/src/app
-RUN pip install .
+
+RUN apk --update add --no-cache --virtual .build-deps \
+    python2-dev=2.7.14-r2 gcc musl-dev libffi-dev openssl-dev && \
+    python -m ensurepip && \
+    pip --no-cache-dir install --upgrade pip setuptools && \
+    pip --no-cache-dir install . && \
+    apk --update del --no-cache .build-deps && \
+    python -m pip uninstall --yes pip setuptools
+
 ENV AWS_DIR /aws
 
 ENTRYPOINT [ "python", "-msamlkeygen" ]

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,4)
+__version_info__ = (1,1,5)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes reduce the docker image size from 742MB uncompressed / 276M compressed  to 97.8 MB uncompressed / 25MB compressed, an 86.8%/90.9% reduction. 

Changes:
Uses alpine image for smaller base image size, install python and runtime dependencies
Combine installing build dependencies, build, uninstall dependencies steps in one command to eliminate layers containing the unnecessary build dependencies remaining in the image on a layer
Add .dockerignore file to not copy in git repo and prebuilt binaries to docker image