### PR TITLE
more thorough flushing; use temp file to avoid conflict with boto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
-RUN apk --update add --no-cache python=2.7.14-r2 bash libffi openssl
+RUN apk --update add --no-cache python=2.7.15-r1 bash libffi openssl
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN apk --update add --no-cache --virtual .build-deps \
-    python2-dev=2.7.14-r2 gcc musl-dev libffi-dev openssl-dev && \
+    python2-dev=2.7.15-r1 gcc musl-dev libffi-dev openssl-dev && \
     python -m ensurepip && \
     pip --no-cache-dir install --upgrade pip setuptools && \
     pip --no-cache-dir install . && \

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,13 @@ clean:
 
 test:
 	bash ./run-tests.sh
+
+docker:
+	docker build -t samlkeygen:$(VERSION) .
+
+tag: docker
+	docker tag samlkeygen:$(VERSION) samlkeygen:latest
+
+push: tag
+	docker push samlkeygen:$(VERSION) turnerlabs/samlkeygen:$(VERSION)
+	docker tag turnerlabs/samlkeygen:$(VERSION) turnerlabs/samlkeygen:latest

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,1,8)
+__version_info__ = (1,2,0)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -279,11 +279,7 @@ def load_profiles(filename, pattern):
 def load_credentials(filename, force_refresh=False):
     if (force_refresh or not load_credentials.config or filename != load_credentials.filename):
         load_credentials.config = configparser.RawConfigParser()
-        # even with the flush/sync calls, we sometimes get an incomplete file;
-        # if the parse fails, try again a couple times before giving up
-        #try:
         load_credentials.config.read(filename)
-        #except 
     return load_credentials.config
 load_credentials.config = None
 load_credentials.filename = None

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -146,7 +146,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
     while auto_update or first:
         try:
             shutil.copyfile(filename, TEMP_FILE)
-        except FileNotFoundError:
+        except IOError:
             pass
         first = False
         processes = []

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -229,7 +229,7 @@ def update_creds_file(filename, profile, token):
     credentials.set(profile, 'last_updated', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
     credentials.set(profile, 'expiration', datetime.strftime(token['Credentials']['Expiration'], '%FT%TZ'))
 
-    with open(TEMP_FILE, 'w') as credsfile:
+    with open(filename, 'w') as credsfile:
         credentials.write(credsfile)
         credsfile.flush()
         os.fsync(credsfile.fileno())

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -415,7 +415,7 @@ def get_account_aliases(url, saml_response, form_action):
 
 # Get the temporary Credentials for the passed in role, using the SAML Assertion as authentication
 def get_sts_token(role_arn, principal_arn, assertion, region, validity=3600):
-    # make sure the STS client request doesn't try to load our creds file
+    # make sure the STS client request doesn't try to use our current AWS_PROFILE
     bs = botocore.session.get_session({ 'profile': ( None, ['', ''], None, None ),
                                         'config_file': (None, '', '', None) })
     bs.set_credentials('','','')


### PR DESCRIPTION
Most users have noticed parse failures during a samlkeygen run - caused by trying to read the credentials file in the middle of it being written. While there are locks in place to prevent the samlkeygen code from competing with itself in this way, there was still the possibility of unflushed buffers, so this PR is more thorough in that regard. 

But it turns out that creating a boto client object for STS automatically triggers an attempted load of the credentials file within botocore, which is what is causing the majority of these failures. And serializing that creation on top of the existing locks makes the tool far too slow to be usable. 

Instead, this version now does what it probably should have done all along: build the new credentials file under a different filename and move it into place only once it's complete. That way, boto or any other program on the system will find a complete credentials file whenever it looks, even while samlkeygen is in the middle of an update.