### PR TITLE
Multiple temples

### DIFF
--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,2,0)
+__version_info__ = (1,3,0)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Give each subprocess its own tempfile not on a host-mounted volume, then merge them together at the end. Speeds things up considerably; Docker version now authenticates 216 roles in 2.5 minutes on my Mac, instead of hitting the 5-minute timeout on the initial SAML authentication without finishing. Still some work to do to get Docker closer to the native-Python time of ~25 seconds for the same conditions.