### PR TITLE
Fix inability to replace existing file on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM alpine:3.8
 
-RUN apk --update add --no-cache python=2.7.15-r1 bash libffi openssl
+RUN apk --update add --no-cache python3=3.6.6-r0 bash libffi openssl
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN apk --update add --no-cache --virtual .build-deps \
-    python2-dev=2.7.15-r1 gcc musl-dev libffi-dev openssl-dev && \
-    python -m ensurepip && \
-    pip --no-cache-dir install --upgrade pip setuptools && \
-    pip --no-cache-dir install . && \
+    python3-dev=3.6.6-r0 gcc musl-dev libffi-dev openssl-dev && \
+    python3 -m ensurepip && \
+    pip3 --no-cache-dir install --upgrade pip setuptools && \
+    pip3 --no-cache-dir install . && \
     apk --update del --no-cache .build-deps && \
-    python -m pip uninstall --yes pip setuptools
+    python3 -m pip uninstall --yes pip setuptools
 
 ENV AWS_DIR /aws
 
-ENTRYPOINT [ "python", "-msamlkeygen" ]
+ENTRYPOINT [ "python3", "-msamlkeygen" ]
 CMD [ "--help" ]

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,3,1)
+__version_info__ = (1,3,2)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -166,7 +166,15 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
             p.join()
 
         merge_ini_files(files, TEMP_FILE)
-        os.rename(TEMP_FILE, filename)
+        try:
+          os.rename(TEMP_FILE, filename)
+        except FileExistsError:
+          if sys.version_info >= (3,3):
+            os.replace(TEMP_FILE, filename)
+          else:
+            os.remove(filename)
+            os.rename(TEMP_FILE, filename)
+
         for f in files:
             os.remove(f)
 


### PR DESCRIPTION
`os.rename` fails on Windows if the target filename exists. `os.replace` works in that case (as long as the file is not in use), but that only exists in Python 3.3+. This change maintains compatibility with older versions of Python.

The strategy is this: try the rename; if it fails with a `FileExistsError`, then  if `os.replace` is available, retry the operation with it; otherwise we accept the risk of the race condition by simply deleting the file and then trying the `rename` again.

To maximize the utility of this change, the Dockerfile has also been updated to build a container based on Python 3.6 instead of 2.7.