### PR TITLE
Limit the number of simultaneous child processes

### DIFF
--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,3,3)
+__version_info__ = (1,3,4)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -44,6 +44,7 @@ TEMP_FILE = CREDS_FILE + '.tmp'
 LOCK_FILE = CREDS_FILE + '.lck'
 AWS_Account_Aliases = []
 AssertionExpires = 0
+MaxProcesses = 20
 
 @arg('--url',          help='URL to ADFS provider', default=os.environ.get('ADFS_URL', ''))
 @arg('--region',       help='AWS region to use', default=os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
@@ -154,6 +155,11 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
         files = []
         started = time.time()
         for account_arn, role_arn in roles:
+
+            if len(processes) > MaxProcesses:
+                 processes[0].join()
+                 del processes[0]
+
             trace('account_arn={}, role_arn={}'.format(account_arn, role_arn));
             (fd, temp_file) = tempfile.mkstemp(text=True)
             os.close(fd)

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -156,7 +156,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
         started = time.time()
         for account_arn, role_arn in roles:
 
-            if len(processes) > MaxProcesses:
+            if len(processes) >= MaxProcesses:
                  processes[0].join()
                  del processes[0]
 


### PR DESCRIPTION
Python 3.7.4 includes a modification to the way Python spawns new processes, to work around a longstanding issue on MacOS (https://bugs.python.org/issue33725). This effectively reduces the number of simultaneous children a Python process can have. In the case of samlkeygen, if you have a large number of SAML roles, you will likely see a variety of errors, ranging from the (correct) "too many open files" to spurious connect() and DNS lookup failures.  

This change limits the number of child processes to 20 at a time, which may slow down an --all-accounts run if you have many accounts, but should allow that run to succeed.