### PR TITLE
global variables are not inherited by child processes on Windows

### DIFF
--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,3,8)
+__version_info__ = (1,3,9)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -166,7 +166,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
             (fd, temp_file) = tempfile.mkstemp(text=True)
             os.close(fd)
             files.append(temp_file)
-            p = Process(target=authenticate_account_role, args=(temp_file, profile, account_arn, role_arn, saml_creds, saml_response, region, validity))
+            p = Process(target=authenticate_account_role, args=(temp_file, profile, account_arn, role_arn, saml_creds, saml_response, region, validity, AssertionExpires))
             p.start()
             processes.append(p)
 
@@ -272,7 +272,9 @@ def write_creds_file(filename, profile, token):
         credsfile.flush()
         os.fsync(credsfile)
 
-def authenticate_account_role(filename, profile_format, principal_arn, role_arn, saml_creds, saml_response, region, validity):
+def authenticate_account_role(filename, profile_format, principal_arn, role_arn, saml_creds, saml_response, region, validity, assertion_expires):
+    global AssertionExpires
+    AssertionExpires = assertion_expires
     if role_arn is None:
         die('Unable to get credentials for null role ARN')
 


### PR DESCRIPTION
This quirk of the way child processes are spawned broke off-network use on Windows by causing all the children to try to re-prompt for the PIN+token.