### PR TITLE
Allow multiple accounts to be specified

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,8 @@ fi
 if [[ -z $TEST_ROLE ]]; then
     read -p 'IAM role name for tests: ' TEST_ROLE
 fi
+# Make sure no AWS_ vars will mess up our tests
+unset $(  export  | sed -ne '/^declare -x AWS_/{;s/^declare -x //;s/=.*//;p;}' )
 TEST_ROOT=/tmp/samlkeygen-tests-$$
 mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/aws"
 AWS_DIR=$TEST_ROOT/aws

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,8 +20,8 @@ TEST_ROOT=/tmp/samlkeygen-tests-$$
 mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/aws"
 AWS_DIR=$TEST_ROOT/aws
 AWS_SHARED_CREDENTIALS_FILE=$AWS_DIR/credentials
-pip install --ignore-installed --prefix="$TEST_ROOT" . awscli
 PATH=$TEST_ROOT/bin:$PATH
+pip install --ignore-installed --prefix="$TEST_ROOT" . awscli
 export PYTHONPATH=$(echo "$TEST_ROOT"/lib/python*/site-packages)
 if ./tests.bats; then
     # all tests succeeded

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,6 +8,9 @@ fi
 if [[ -z $TEST_ACCOUNT ]]; then
     read -p 'AWS account name for tests: ' TEST_ACCOUNT
 fi
+if [[ -z $TEST_ACCOUNT2 ]]; then
+    read -p 'Another AWS account name for tests: ' TEST_ACCOUNT2
+fi
 if [[ -z $TEST_ROLE ]]; then
     read -p 'IAM role name for tests: ' TEST_ROLE
 fi

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,3,9)
+__version_info__ = (1,4,0)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -57,7 +57,7 @@ MaxProcesses = 20
 @arg('--auto-update',  help='Continue running and update token(s) before they expire')
 @arg('--domain',       help='Windows domain to authenticate to', default=os.environ.get('ADFS_DOMAIN', ''))
 @arg('--username',     help='Name of user to authenticate as', default=getpass.getuser())
-@arg('--password',     help='Password for user', default=None)
+@arg('--password',     help='Password for user', default=os.environ.get('ADFS_PASSWORD', None))
 @arg('--verbose',      help='Display trace output', default=False)
 @arg('--duration',     help='Duration of token validity, in hours', default=9)
 def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_DEFAULT_REGION','us-east-1'),

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -101,6 +101,8 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
     roles = all_roles = extract_roles(saml_response)
     if accounts:
         roles = []
+    else:
+        accounts = []    # set to empty list instead of None if unspecified
 
     # if account is specified, look for it as an existing profile first
     for account in accounts:

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -51,7 +51,7 @@ MaxProcesses = 20
 @arg('--batch',        help='Disable all interactive prompts')
 @arg('--all-accounts', help='Retrieve tokens for all accounts and roles')
 @arg('--profile',      help='Naming pattern for profile names; %%a=account alias, %%r=role name (default %%a:%%r)')
-@arg('--accounts',     help='Name(s) or ID(s) of AWS account(s) for which to generate tokens', nargs='*')
+@arg('--accounts',     help='Name(s) or ID(s) of AWS account(s) for which to generate tokens', nargs='+')
 @arg('--role',         help='Name or ARN of role for which to generate token (default: all for account)')
 @arg('--filename',     help='Name of AWS credentials file', default=CREDS_FILE)
 @arg('--auto-update',  help='Continue running and update token(s) before they expire')

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -51,7 +51,7 @@ MaxProcesses = 20
 @arg('--batch',        help='Disable all interactive prompts')
 @arg('--all-accounts', help='Retrieve tokens for all accounts and roles')
 @arg('--profile',      help='Naming pattern for profile names; %%a=account alias, %%r=role name (default %%a:%%r)')
-@arg('--account',      help='Name or ID of AWS account for which to generate token')
+@arg('--accounts',     help='Name(s) or ID(s) of AWS account(s) for which to generate tokens', nargs='*')
 @arg('--role',         help='Name or ARN of role for which to generate token (default: all for account)')
 @arg('--filename',     help='Name of AWS credentials file', default=CREDS_FILE)
 @arg('--auto-update',  help='Continue running and update token(s) before they expire')
@@ -61,7 +61,7 @@ MaxProcesses = 20
 @arg('--verbose',      help='Display trace output', default=False)
 @arg('--duration',     help='Duration of token validity, in hours', default=9)
 def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_DEFAULT_REGION','us-east-1'),
-                 batch=False, all_accounts=False, account=None,
+                 batch=False, all_accounts=False, accounts=None,
                  profile='%a:%r', domain=os.environ.get('ADFS_DOMAIN',''), role=None, username=os.environ.get('USER',''),
                  password=None, filename=CREDS_FILE, auto_update=False, verbose=False, duration=9):
     "Authenticate via SAML and write out temporary security tokens to the credentials file"
@@ -69,11 +69,11 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
     if verbose:
         trace_on()
 
-    if not (all_accounts or account):
-        die('Need --account or --all-accounts')
+    if not (all_accounts or accounts):
+        die('Need --accounts or --all-accounts')
 
-    if all_accounts and account:
-        die('Specify --account or --all-accounts, not both.')
+    if all_accounts and accounts:
+        die('Specify --accounts or --all-accounts, not both.')
 
     # check to see if url hostname resolves to 10 network and assume VPN connection is up
     if not url:
@@ -98,11 +98,15 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
 
     saml_creds, saml_response = authorize(url, domain, username, password, batch)
 
-    roles = extract_roles(saml_response)
+    roles = all_roles = extract_roles(saml_response)
+    if accounts:
+        roles = []
 
     # if account is specified, look for it as an existing profile first
-    account_arn = None
-    if account:
+    for account in accounts:
+      account_arn = None
+      found_roles = []
+      if account:
         try:
             account_id = int(account)
         except ValueError:
@@ -110,7 +114,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
         if account_id:
             account = f'arn:aws:iam::{account_id:012}'
         regex = re.compile(account)
-        for principal_arn, role_arn in roles:
+        for principal_arn, role_arn in all_roles:
             if regex.search(principal_arn):
                 account_arn = principal_arn
                 break
@@ -118,17 +122,19 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
         if not account_arn:
             if account_id:
                 raise LookupError('no profile found matching account id "{:012}"'.format(account_id))
-            for principal_arn, role_arn in roles:
+            for principal_arn, role_arn in all_roles:
                 account_name = get_account_name(principal_arn, saml_response, role_arn, region)
                 if regex.search(account_name):
                     account_arn = principal_arn
                     break
 
-    if account_arn:
-        roles = [r for r in roles if r[0] == account_arn]
+      if account_arn:
+        found_roles = [r for r in all_roles if r[0] == account_arn]
 
-    if account_arn and not roles:
+      if account_arn and not found_roles:
         die('Account {} not found.'.format(account))
+
+      roles += found_roles
 
     # if a role is specified, find it
     if role:

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -104,7 +104,7 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
     else:
         accounts = []    # set to empty list instead of None if unspecified
 
-    # if account is specified, look for it as an existing profile first
+    # if accounts specified, look for existing profiles first
     for account in accounts:
       account_arn = None
       found_roles = []

--- a/tests.bats
+++ b/tests.bats
@@ -63,9 +63,10 @@ fi
    sleep 15
    kill $pid
    wait $pid 2>/dev/null || true
-   [[ $(tail -n 1 "$tmpfile") == *credential*refresh* ]]
-   result=$?
-   cat "$tmpfile"
-   rm -f "$tmpfile"
-   return $result
+   if [[ $(tail -n 1 "$tmpfile") == *credential*refresh* ]]; then
+     rm -f "$tmpfile"
+     return 0
+   else
+     return $?
+   fi
 }

--- a/tests.bats
+++ b/tests.bats
@@ -13,12 +13,16 @@ fi
    [[ $(python -msamlkeygen 2>&1) == 'usage: samlkeygen '* ]]
 }
 
-@test "usage 2: authenticate requires account"  {
-   [[ $(python -msamlkeygen authenticate 2>&1 | tail -n 1) == 'samlkeygen: Need --account or --all-accounts' ]]
+@test "usage 2: authenticate requires accounts"  {
+   [[ $(python -msamlkeygen authenticate 2>&1 | tail -n 1) == 'samlkeygen: Need --accounts or --all-accounts' ]]
 }
 
-@test "authenticate --account doesn't crash"  {
-   python -msamlkeygen authenticate --account "$TEST_ACCOUNT" --password "$ADFS_PASSWORD" >&/dev/null
+@test "authenticate --accounts doesn't crash"  {
+   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" --password "$ADFS_PASSWORD" >&/dev/null
+}
+
+@test "authenticate --accounts takes multiple accounts"  {
+   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" "$TEST_ACCOUNT2" --password "$ADFS_PASSWORD" >&/dev/null
 }
 
 @test "format in --profile works"  {
@@ -61,6 +65,7 @@ fi
    wait $pid 2>/dev/null || true
    [[ $(tail -n 1 "$tmpfile") == *credential*refresh* ]]
    result=$?
+   cat "$tmpfile"
    rm -f "$tmpfile"
    return $result
 }


### PR DESCRIPTION
This allows the `--account` option to take multiple arguments, for easily generating keys for only a subset of your SAML roles with just one authentication. Previously your choices were a single role or all of them. 