### PR TITLE
Use aliases list to find accounts specified on the command line

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,7 +17,7 @@ fi
 # Make sure no AWS_ vars will mess up our tests
 unset $(  export  | sed -ne '/^declare -x AWS_/{;s/^declare -x //;s/=.*//;p;}' )
 TEST_ROOT=/tmp/samlkeygen-tests-$$
-mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/aws"
+mkdir -p "$TEST_ROOT/bin"
 AWS_DIR=$TEST_ROOT/aws
 AWS_SHARED_CREDENTIALS_FILE=$AWS_DIR/credentials
 PATH=$TEST_ROOT/bin:$PATH

--- a/samlkeygen/_version.py
+++ b/samlkeygen/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1,4,0)
+__version_info__ = (1,4,1)
 __version__ = '.'.join(str(d) for d in __version_info__)
 
 if __name__ == '__main__':

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -226,6 +226,8 @@ def merge_ini_files(source_files, target_file):
                 target.add_section(sect)
             for (key, value) in source.items(sect):
                 target.set(sect, key, value)
+
+    os.makedirs(os.path.dirname(target_file), exist_ok=True)
     with open(target_file, 'wt') as f:
         target.write(f)
 
@@ -287,6 +289,7 @@ def write_creds_file(filename, profile, token):
     credentials.set(profile, 'last_updated', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
     credentials.set(profile, 'expiration', datetime.strftime(token['Credentials']['Expiration'], '%FT%TZ'))
 
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, 'wt') as credsfile:
         credentials.write(credsfile)
         credsfile.flush()

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -127,9 +127,9 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
                 raise LookupError('no profile found matching account id "{:012}"'.format(account_id))
             for pair in AWS_Account_Aliases:
                 if regex.search(pair['alias']):
-                    arn_regex = re.compile(f'arn:aws:iam::{int(pair["id"]):012}')
+                    arn_prefix = f'arn:aws:iam::{int(pair["id"]):012}:'
                     for principal_arn, role_arn in all_roles:
-                      if arn_regex.search(principal_arn):
+                      if principal_arn.startswith(arn_prefix):
                          account_arn = principal_arn
                          break
                     break

--- a/samlkeygen/entry_points.py
+++ b/samlkeygen/entry_points.py
@@ -127,9 +127,9 @@ def authenticate(url=os.environ.get('ADFS_URL',''), region=os.environ.get('AWS_D
                 raise LookupError('no profile found matching account id "{:012}"'.format(account_id))
             for pair in AWS_Account_Aliases:
                 if regex.search(pair['alias']):
-                    regex = re.compile(f'arn:aws:iam::{int(pair["id"]):012}')
+                    arn_regex = re.compile(f'arn:aws:iam::{int(pair["id"]):012}')
                     for principal_arn, role_arn in all_roles:
-                      if regex.search(principal_arn):
+                      if arn_regex.search(principal_arn):
                          account_arn = principal_arn
                          break
                     break

--- a/tests.bats
+++ b/tests.bats
@@ -17,16 +17,16 @@ fi
    [[ $(python -msamlkeygen authenticate 2>&1 | tail -n 1) == 'samlkeygen: Need --accounts or --all-accounts' ]]
 }
 
-@test "authenticate --accounts doesn't crash"  {
-   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" --password "$ADFS_PASSWORD" 
+@test "authenticate works when aws dir is not there yet"  {
+   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" 
 }
 
 @test "authenticate --accounts takes multiple accounts"  {
-   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" "$TEST_ACCOUNT2" --password "$ADFS_PASSWORD" 
+   python -msamlkeygen authenticate --accounts "$TEST_ACCOUNT" "$TEST_ACCOUNT2"
 }
 
 @test "format in --profile works"  {
-   python -msamlkeygen authenticate --account "$TEST_ACCOUNT" --role "$TEST_ROLE" --profile '%r' --password "$ADFS_PASSWORD" 
+   python -msamlkeygen authenticate --account "$TEST_ACCOUNT" --role "$TEST_ROLE" --profile '%r'
    grep -q "^\[$TEST_ROLE\]" "$AWS_DIR"/credentials
 }
 
@@ -58,7 +58,7 @@ fi
 @test "samld entry point works"  {
    local pid result tmpfile wait_time
    tmpfile=$TEST_ROOT/samld$$.out
-   (samld --password "$ADFS_PASSWORD") > "$tmpfile" 2>&1 &
+   (samld) > "$tmpfile" 2>&1 &
    pid=$!
    wait_time=15
    if [[ -r ~/.aws/credentials ]]; then


### PR DESCRIPTION
We're already scraping the HTML for alias/id mappings but not using the list to look up aliases specified on the command line.  Do that.

Also fixes #23, creating the path leading to the creds file if it doesn't exist.